### PR TITLE
Fix broken image link

### DIFF
--- a/guide/1.0.0-alpha1/ApplicationArchitecture.html
+++ b/guide/1.0.0-alpha1/ApplicationArchitecture.html
@@ -478,7 +478,7 @@ app.run(WindowCreateOptions(layoutFunc))
 </p>
 
 <br/>
-<img src="https://docs.unrealengine.com/Images/ProgrammingAndScripting/Blueprints/UserGuide/Nodes/SelectNode.jpg" style="width:100%;"/>
+<img src="https://docs.unrealengine.com/4.26/Images/ProgrammingAndScripting/Blueprints/UserGuide/Nodes/SelectNode.webp" style="width:100%;"/>
 
 <p>
     Azul includess a built-in <code>NodeGraph</code> as a default widget, so let's


### PR DESCRIPTION
This the link to this image is currently broken at: https://azul.rs/guide/1.0.0-alpha1/ApplicationArchitecture
You may want to save a copy of it to prevent future breakage, or, if it causes concern for copyright issues perhaps design a custom image that demonstrates UI nodes.
The page where that image can be found is archived here: https://web.archive.org/web/20210724230810/https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/Blueprints/UserGuide/Nodes/